### PR TITLE
find_cat: use categories.dat from rootfs-skeleton, not system-wide

### DIFF
--- a/pkg/w_apps_static/w_apps/find_cat.c
+++ b/pkg/w_apps_static/w_apps/find_cat.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
 	setvbuf(stdout, outbuf, BUF_SIZE, _IOFBF);
 
 	buf = malloc(BUF_SIZE);
-	catf = fopen("/usr/local/petget/categories.dat", "r");
+	catf = fopen("./rootfs-skeleton/usr/local/petget/categories.dat", "r");
 	if (NULL == catf) goto bail;
 
 	initcrc = crc32(0, NULL, 0);

--- a/pkg/w_apps_static/w_apps/find_cat.c
+++ b/pkg/w_apps_static/w_apps/find_cat.c
@@ -113,9 +113,9 @@ int main(int argc, char *argv[])
 	setvbuf(stdout, outbuf, BUF_SIZE, _IOFBF);
 
 	buf = malloc(BUF_SIZE);
-	catf = fopen("/usr/local/petget/categories.dat", "r");
-	if (NULL == catf) // local copy if system-wide is not found
 	catf = fopen("./rootfs-skeleton/usr/local/petget/categories.dat", "r");
+	if (NULL == catf) // system-wide if local is not found
+	catf = fopen("/usr/local/petget/categories.dat", "r");
 	if (NULL == catf) goto bail;
 
 	initcrc = crc32(0, NULL, 0);

--- a/pkg/w_apps_static/w_apps/find_cat.c
+++ b/pkg/w_apps_static/w_apps/find_cat.c
@@ -113,6 +113,8 @@ int main(int argc, char *argv[])
 	setvbuf(stdout, outbuf, BUF_SIZE, _IOFBF);
 
 	buf = malloc(BUF_SIZE);
+	catf = fopen("/usr/local/petget/categories.dat", "r");
+	if (NULL == catf) // local copy if system-wide is not found
 	catf = fopen("./rootfs-skeleton/usr/local/petget/categories.dat", "r");
 	if (NULL == catf) goto bail;
 


### PR DESCRIPTION
This enables 0setup to run successfully on non-Puppy platform. 